### PR TITLE
Ignore additional SQS properties

### DIFF
--- a/pytest_serverless.py
+++ b/pytest_serverless.py
@@ -41,7 +41,7 @@ def _handle_sqs_queue(resources):
         sqs.start()
 
         for resource_definition in resources:
-            boto3.resource("sqs").create_queue(**resource_definition["Properties"])
+            boto3.resource("sqs").create_queue(QueueName=resource_definition["Properties"]["QueueName"])
 
     def after():
         sqs_client = boto3.client("sqs")

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,6 +5,24 @@ resources:
      Type: "AWS::SQS::Queue"
      Properties:
        QueueName: my-super-queue
+   EventQueue2:
+     Type: "AWS::SQS::Queue"
+     Properties:
+       QueueName: my-super-queue2
+       DelaySeconds: 0
+       FifoQueue: false
+       KmsDataKeyReusePeriodSeconds: 300
+       MaximumMessageSize: 262144
+       MessageRetentionPeriod: 2000
+       ReceiveMessageWaitTimeSeconds: 0
+       RedrivePolicy: 
+         deadLetterTargetArn : "arn:aws:sqs:us-east-2:444455556666:queue1"
+         maxReceiveCount : 1
+       Tags: 
+         - 
+           key: "key1"
+           value: "value1"
+       VisibilityTimeout: 1000
    TableA:
      Type: 'AWS::DynamoDB::Table'
      DeletionPolicy: Delete


### PR DESCRIPTION
Additional SQS properties other than QueueName cause an exception when using the pytest-serverless fixture.  This PR resolves this issue by ignoring properties other than QueueName.

CloudFormation supports a number of properties when defining an SQS queue (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html).  These should be defined as `Attributes` per the SQS boto3 resource (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#SQS.ServiceResource.create_queue).  Since the objective is to mock the resource, rather than properly evaluating each of the attributes, this PR simply ignores them.