### PR TITLE
Set environment variables defined in serverless.yml file

### DIFF
--- a/pytest_serverless.py
+++ b/pytest_serverless.py
@@ -166,6 +166,9 @@ def serverless():
     if not _serverless_yml_dict:
         _serverless_yml_dict = _load_file()
 
+    for k, v in _serverless_yml_dict["provider"].get("environment", {}).items():
+        os.environ[k] = v
+
     actions_before = []
     actions_after = []
 
@@ -198,10 +201,10 @@ def _load_file():
     if not which("sls"):
         raise Exception("No sls executable found!")
 
-    result = subprocess.run(['sls', 'print'], stdout=subprocess.PIPE)
+    result = subprocess.run(["sls", "print"], stdout=subprocess.PIPE)
     serverless_content = result.stdout.decode("utf-8").replace(
         'Serverless: Running "serverless" installed locally (in service node_modules)\n',
-        ""
+        "",
     )
 
     return yaml.safe_load(serverless_content)

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,6 +2,8 @@ service: my-microservice
 provider:
   name: aws
   runtime: python3.8
+  environment:
+    SERVICE: ${self:service}
 resources:
  Resources:
    EventQueue:

--- a/test_pytest_serverless.py
+++ b/test_pytest_serverless.py
@@ -1,3 +1,5 @@
+import os
+
 import boto3
 import pytest
 
@@ -5,6 +7,9 @@ import pytest
 class TestGeneral:
     @pytest.mark.usefixtures("serverless")
     def test_it_replaces_local_variable_with_its_value(self):
+        """
+        This test checks if `${self:service}` from `serverless.yml` will be replaced with `my-microservice` value
+        """
         table = boto3.resource("dynamodb").Table("my-microservice.my-table")
         count_of_items = len(table.scan()["Items"])
         assert count_of_items == 0
@@ -12,6 +17,10 @@ class TestGeneral:
         table.put_item(Item={"id": "my-id"})
         count_of_items = len(table.scan()["Items"])
         assert count_of_items == 1
+
+    @pytest.mark.usefixtures("serverless")
+    def test_it_sets_environment_variables_defined_in_serverless_yml_file(self):
+        assert os.environ.get("SERVICE") == "my-microservice"
 
 
 class TestDynamoDb:


### PR DESCRIPTION
@I-himawari suggested improvement in https://github.com/whisller/pytest-serverless/pull/29 which sets env variables defined in `serverless.yml` file.
This PR introduces this functionality.