### PR TITLE
Add custom serverless path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ def test():
     assert count_of_items == 0
 ```
 
+You can use a custom serverless file path setting the envionmnet variable `SERVERLESS_FILE_PATH`.
+
+```shell
+$ export SERVERLESS_FILE_PATH=/path/to/serverless.yml
+```
+
 ## Supported resources
 ### AWS::DynamoDB::Table
 ### AWS::SQS::Queue

--- a/pytest_serverless.py
+++ b/pytest_serverless.py
@@ -225,7 +225,9 @@ def serverless():
 
 
 def _load_file():
-    is_serverless = os.path.isfile("serverless.yml")
+    serverless_path = os.environ.get("SERVERLESS_FILE_PATH", "serverless.yml")
+
+    is_serverless = os.path.isfile(serverless_path)
     if not is_serverless:
         raise Exception("No serverless.yml file found!")
 
@@ -235,7 +237,7 @@ def _load_file():
     env = os.environ.copy()
     env["SLS_DEPRECATION_DISABLE"] = "*"
     env["SLS_WARNING_DISABLE"] = "*"
-    result = subprocess.run(["sls", "print"], stdout=subprocess.PIPE, env=env)
+    result = subprocess.run(["sls", "print", "--config", serverless_path], stdout=subprocess.PIPE, env=env)
     serverless_content = result.stdout.decode("utf-8").replace(
         'Serverless: Running "serverless" installed locally (in service node_modules)\n',
         "",


### PR DESCRIPTION
Add support to using a custom serverless file path, setting the environment variable `SERVERLESS_FILE_PATH`.