### PR TITLE
Add custom serverless command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ You can use a custom serverless file path setting the envionmnet variable `SERVE
 $ export SERVERLESS_FILE_PATH=/path/to/serverless.yml
 ```
 
+You can use choose both `sls` or `serverless` command to run, settings the environment variable `SERVERLESS_COMMAND`. It will only accpets `sls` or `serverless` values.
+
+```shell
+$ export SERVERLESS_FILE_PATH=sls
+
+$ export SERVERLESS_FILE_PATH=serverless
+```
+
 ## Supported resources
 ### AWS::DynamoDB::Table
 ### AWS::SQS::Queue

--- a/pytest_serverless.py
+++ b/pytest_serverless.py
@@ -226,18 +226,22 @@ def serverless():
 
 def _load_file():
     serverless_path = os.environ.get("SERVERLESS_FILE_PATH", "serverless.yml")
+    serverless_command = os.environ.get("SERVERLESS_COMMAND", "sls")
 
     is_serverless = os.path.isfile(serverless_path)
     if not is_serverless:
         raise Exception("No serverless.yml file found!")
 
-    if not which("sls"):
-        raise Exception("No sls executable found!")
+    if serverless_command != "sls" and serverless_command != "serverless":
+        raise Exception("Command %s not releated to serverless" % serverless_command)
+
+    if not which(serverless_command):
+        raise Exception("No %s executable found!" % serverless_command)
 
     env = os.environ.copy()
     env["SLS_DEPRECATION_DISABLE"] = "*"
     env["SLS_WARNING_DISABLE"] = "*"
-    result = subprocess.run(["sls", "print", "--config", serverless_path], stdout=subprocess.PIPE, env=env)
+    result = subprocess.run([serverless_command, "print", "--config", serverless_path], stdout=subprocess.PIPE, env=env)
     serverless_content = result.stdout.decode("utf-8").replace(
         'Serverless: Running "serverless" installed locally (in service node_modules)\n',
         "",

--- a/pytest_serverless.py
+++ b/pytest_serverless.py
@@ -232,7 +232,7 @@ def _load_file():
     if not is_serverless:
         raise Exception("No serverless.yml file found!")
 
-    if serverless_command != "sls" and serverless_command != "serverless":
+    if serverless_command not in ("sls", "serverless"):
         raise Exception("Command %s not releated to serverless" % serverless_command)
 
     if not which(serverless_command):


### PR DESCRIPTION
Add support to choose between `sls` and `serverless` to the library run, setting the env variable to run `SERVERLESS_COMMAND`.