### PR TITLE
Stripping all informational serverless messages from rendered yaml file

### DIFF
--- a/pytest_serverless.py
+++ b/pytest_serverless.py
@@ -6,6 +6,7 @@ from shutil import which
 import boto3
 import pytest
 import yaml
+from re import sub
 from yaml.scanner import ScannerError
 
 _serverless_yml_dict = None
@@ -242,10 +243,7 @@ def _load_file():
     env["SLS_DEPRECATION_DISABLE"] = "*"
     env["SLS_WARNING_DISABLE"] = "*"
     result = subprocess.run([serverless_command, "print", "--config", serverless_path], stdout=subprocess.PIPE, env=env)
-    serverless_content = result.stdout.decode("utf-8").replace(
-        'Serverless: Running "serverless" installed locally (in service node_modules)\n',
-        "",
-    )
+    serverless_content = sub(r'Serverless: [^\n]*\n', "", result.stdout.decode("utf-8"))
 
     try:
         return yaml.safe_load(serverless_content)


### PR DESCRIPTION
**Context**

Rendering the serverless yaml file via `sls print` can result in a number of informational serverless messages in addition to the actual yaml code - for example, `Serverless: Using provider credentials, configured via dashboard...`). Rather than hardcode a single message to ignore - `Serverless: Running "serverless" installed locally (in service node_modules)` - let's ignore all these informational messages in order to only retrieve the rendered yaml itself. This will make this package viable for a wider variety of situations (as well as guard against future changes made to the print output by serverless).

**Changeset**

- Strips all informational serverless messages